### PR TITLE
Improve concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ CHANNEL_LAYERS = {
             'HOST': '127.0.0.1',
             'PORT': '5432',
 
-            'async_lib_config: {
+            'config: {
                 ...
             }
         },
@@ -53,9 +53,9 @@ CHANNEL_LAYERS = {
 
 The Config object is exactly the same as the standard config object for Django's PostgreSQL database. See the django documentation for more information.
 
-`async_lib_config` is a dictionary of parameters to the underlying async postgres library (in this case `aiopg`) This setting can be used to control the database pool size, connection timeout etc. See the [aiopg documentation](https://aiopg.readthedocs.io/en/stable/core.html?highlight=pool#pool) for more information.
+`config` is a dictionary of parameters to the underlying async postgres library (in this case `aiopg`) This setting can be used to control the database pool size, connection timeout etc. See the [aiopg documentation](https://aiopg.readthedocs.io/en/stable/core.html?highlight=pool#pool) for more information.
 
-A typical use of `async_lib_config` would be to increase the `maxsize` of the connection pool. The default of 10 might be too low for sites with a decent amount of traffic.
+A typical use of `config` would be to increase the `maxsize` of the connection pool. The default of 10 might be too low for sites with a decent amount of traffic.
 
 The config parameters are described below:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ CHANNEL_LAYERS = {
             'PASSWORD': 'password',
             'HOST': '127.0.0.1',
             'PORT': '5432',
+
+            'async_lib_config: {
+                ...
+            }
         },
     },
 }
@@ -49,7 +53,11 @@ CHANNEL_LAYERS = {
 
 The Config object is exactly the same as the standard config object for Django's PostgreSQL database. See the django documentation for more information.
 
-Extra config params are described below:
+`async_lib_config` is a dictionary of parameters to the underlying async postgres library (in this case `aiopg`) This setting can be used to control the database pool size, connection timeout etc. See the [aiopg documentation](https://aiopg.readthedocs.io/en/stable/core.html?highlight=pool#pool) for more information.
+
+A typical use of `async_lib_config` would be to increase the `maxsize` of the connection pool. The default of 10 might be too low for sites with a decent amount of traffic.
+
+The config parameters are described below:
 
 ### prefix
 

--- a/channels_postgres/core.py
+++ b/channels_postgres/core.py
@@ -38,13 +38,16 @@ class PostgresChannelLayer(BaseChannelLayer):
 
     def __init__(
         self, prefix='asgi', expiry=60, group_expiry=0,
-        symmetric_encryption_keys=None, **kwargs
+        symmetric_encryption_keys=None, async_lib_config=dict(),
+        **kwargs
     ):
         self.prefix = prefix
         self.expiry = expiry
         self.group_expiry = group_expiry
         self.client_prefix = uuid.uuid4().hex[:5]
         self._setup_encryption(symmetric_encryption_keys)
+
+        self.async_lib_config = async_lib_config
 
         try:
             kwargs['OPTIONS']
@@ -63,7 +66,7 @@ class PostgresChannelLayer(BaseChannelLayer):
 
         if pool is None:
             creating_pool = True
-            pool = await aiopg.create_pool(**self.db_params)
+            pool = await aiopg.create_pool(**self.db_params, **self.async_lib_config)
             creating_pool = False
 
         return pool

--- a/channels_postgres/db.py
+++ b/channels_postgres/db.py
@@ -1,5 +1,6 @@
 """common db methods."""
 
+import random
 import asyncio
 import logging
 
@@ -13,41 +14,6 @@ class DatabaseLayer:
 
         if not self.logger:
             self.logger = logging.getLogger('channels_postgres.database')
-
-    async def send_to_channel(self, conn, group_key, message, expire, channel=None):
-        """Send a message on a channel."""
-        cur = await conn.cursor()
-        if channel is None:
-            channels = await self._retrieve_group_channels(cur, group_key)
-        else:
-            channels = [channel]
-
-        insert_message_sql = (
-            'INSERT INTO channels_postgres_message (channel, message, expire) VALUES '
-        )
-
-        last_channel = channels.pop()
-
-        values = []
-        for channel in channels:
-            insert_message_sql = insert_message_sql + "(%s, %s, (NOW() + INTERVAL '%s seconds')), "
-            values.extend((channel, message, expire))
-
-        insert_message_sql = insert_message_sql + "(%s, %s, (NOW() + INTERVAL '%s seconds'));"
-        values.extend((last_channel, message, expire))
-
-        await cur.execute(insert_message_sql, values)
-
-    async def add_channel_to_group(self, conn, group_key, channel, expire):
-        group_add_sql = (
-            'INSERT INTO channels_postgres_groupchannel (group_key, channel, expire) '
-            "VALUES (%s, %s, (NOW() + INTERVAL '%s seconds'))"
-        )
-
-        cur = await conn.cursor()
-        await cur.execute(group_add_sql, (group_key, channel, expire))
-
-        self.logger.debug('Channel %s added to Group %s', channel, group_key)
 
     async def _retrieve_group_channels(self, cur, group_key):
         retrieve_channels_sql = (
@@ -63,22 +29,58 @@ class DatabaseLayer:
 
         return channels
 
+    async def send_to_channel(self, conn, group_key, message, expire, channel=None):
+        """Send a message to a channel/channels (if no channel is specified)."""
+        cur = await conn.cursor()
+        if channel is None:
+            channels = await self._retrieve_group_channels(cur, group_key)
+        else:
+            channels = [channel]
+
+        values_str = b','.join(
+            cur.mogrify(
+                "(%s, %s, (NOW() + INTERVAL '%s seconds'))", (channel, message, expire)
+            ) for channel in channels
+        )
+        insert_message_sql = (
+            b'INSERT INTO channels_postgres_message (channel, message, expire) VALUES ' + values_str
+        )
+
+        await cur.execute(insert_message_sql)
+
+    async def add_channel_to_group(self, conn, group_key, channel, expire):
+        group_add_sql = (
+            'INSERT INTO channels_postgres_groupchannel (group_key, channel, expire) '
+            "VALUES (%s, %s, (NOW() + INTERVAL '%s seconds'))"
+        )
+
+        cur = await conn.cursor()
+        await cur.execute(group_add_sql, (group_key, channel, expire))
+
+        self.logger.debug('Channel %s added to Group %s', channel, group_key)
+
     async def delete_expired_groups(self, db_params):
+        expire = 60 * random.randint(10, 20)
+        self.logger.debug('Deleting expired groups in %s seconds...', expire)
+
         await asyncio.sleep(60)
         delete_sql = (
             'DELETE FROM channels_postgres_groupchannel '
             'WHERE expire < NOW()'
         )
-        conn = await aiopg.connect(**db_params)
-        cur = await conn.cursor()
-        await cur.execute(delete_sql)
+        async with aiopg.connect(**db_params) as conn:
+            cur = await conn.cursor()
+            await cur.execute(delete_sql)
 
     async def delete_expired_messages(self, db_params):
+        expire = 60 * random.randint(10, 20)
+        self.logger.debug('Deleting expired messages in %s seconds...', expire)
+
         await asyncio.sleep(60)
         delete_sql = (
             'DELETE FROM channels_postgres_message '
             'WHERE expire < NOW()'
         )
-        conn = await aiopg.connect(**db_params)
-        cur = await conn.cursor()
-        await cur.execute(delete_sql)
+        async with aiopg.connect(**db_params) as conn:
+            cur = await conn.cursor()
+            await cur.execute(delete_sql)

--- a/channels_postgres/db.py
+++ b/channels_postgres/db.py
@@ -10,39 +10,57 @@ from channels_postgres.models import GroupChannel, Message
 
 class DatabaseLayer:
     def __init__(self, using='channels_postgres', logger=None):
-        self.using = using
         self.logger = logger
+        self.using = using
 
         if not self.logger:
             self.logger = logging.getLogger('channels_postgres.database')
 
-    @database_sync_to_async
-    def send_to_channel(self, channels, message, expire):
+    async def send_to_channel(self, conn, group_key, message, expire):
         """Send a message on a channel."""
-        messages = []
-        for channel in channels:
-            message_obj = Message(
-                channel=channel, message=message,
-                expire=timezone.now() + timezone.timedelta(seconds=expire)
-            )
-            messages.append(message_obj)
+        cur = await conn.cursor()
+        channels = await self._retrieve_group_channels(cur, group_key)
 
-        Message.objects.using(self.using).bulk_create(messages)
-
-    @database_sync_to_async
-    def add_channel_to_group(self, group_key, channel, expire):
-        GroupChannel.objects.using(self.using).create(
-            group_key=group_key, channel=channel,
-            expire=timezone.now() + timezone.timedelta(seconds=expire)
+        insert_message_sql = (
+            'INSERT INTO channels_postgres_message (channel, message, expire) VALUES '
         )
+
+        last_channel = channels.pop()
+
+        values = []
+        for channel in channels:
+            insert_message_sql = insert_message_sql + "(%s, %s, (NOW() + INTERVAL '%s seconds')), "
+            values.extend((channel, message, expire))
+
+        insert_message_sql = insert_message_sql + "(%s, %s, (NOW() + INTERVAL '%s seconds'));"
+        values.extend((last_channel, message, expire))
+
+        await cur.execute(insert_message_sql, values)
+
+    async def add_channel_to_group(self, conn, group_key, channel, expire):
+        group_add_sql = (
+            'INSERT INTO channels_postgres_groupchannel (group_key, channel, expire) '
+            "VALUES (%s, %s, (NOW() + INTERVAL '%s seconds'))"
+        )
+
+        cur = await conn.cursor()
+        await cur.execute(group_add_sql, (group_key, channel, expire))
 
         self.logger.debug('Channel %s added to Group %s', channel, group_key)
 
-    @database_sync_to_async
-    def retrieve_group_channels(self, group_key):
-        return GroupChannel.objects.using('channels_postgres').filter(
-            group_key=group_key
-        ).distinct('channel').values_list('channel', flat=True)
+    async def _retrieve_group_channels(self, cur, group_key):
+        retrieve_channels_sql = (
+            'SELECT DISTINCT group_key,channel '
+            'FROM channels_postgres_groupchannel WHERE group_key=%s;'
+        )
+
+        await cur.execute(retrieve_channels_sql, (group_key,))
+
+        channels = []
+        async for row in cur:
+            channels.append(row[1])
+
+        return channels
 
     @database_sync_to_async
     def delete_expired_groups(self):


### PR DESCRIPTION
- Delete expired groups and messages when a client disconnects
- Use a different connection pool for short-lived connections
