### PR TITLE
No LISTEN events received

### DIFF
--- a/channels_postgres/core.py
+++ b/channels_postgres/core.py
@@ -142,7 +142,7 @@ class PostgresChannelLayer(BaseChannelLayer):
                 conn._notifies = asyncio.Queue()
 
                 await cur.execute(retrieve_events_sql)
-                event = await conn.notifies.get()
+                event = await conn._notifies.get()
                 message_id = event.payload
 
                 retrieve_message_sql = (


### PR DESCRIPTION
I received no messages that has been send to a group. The notification has been triggered on the Postgres database but because of a typo no events occured on the channels belonging to the group.