### PR TITLE
Remove async_generator.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.6
+        - 3.6.9
         - 3.7
         - 3.8
         - 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.6.9
+        - 3.6.11
         - 3.7
         - 3.8
         - 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,16 @@ jobs:
   tests:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - 3.6.11
-        - 3.7
-        - 3.8
-        - 3.9
+        python-version: [3.7, 3.8, 3.9]
+        experimental: [false]
+        include:
+          - python-version: 3.6
+            os: ubuntu-latest
+            experimental: true
 
     services:
       postgres:

--- a/channels_postgres/core.py
+++ b/channels_postgres/core.py
@@ -213,7 +213,7 @@ class PostgresChannelLayer(BaseChannelLayer):
                 conn, group_key, channel, self.group_expiry
             )
 
-    async def group_discard(self, group, channel):
+    async def group_discard(self, group, channel, expire=None):
         """
         Removes the channel from the named group if it is in the group;
         does nothing otherwise (does not error)
@@ -235,7 +235,7 @@ class PostgresChannelLayer(BaseChannelLayer):
         if self.group_expiry > 0:
             create_task(self.django_db.delete_expired_groups(self.db_params))
 
-        create_task(self.django_db.delete_expired_messages(self.db_params))
+        create_task(self.django_db.delete_expired_messages(self.db_params, expire))
 
     async def group_send(self, group, message):
         """Sends a message to the entire group."""

--- a/channels_postgres/db.py
+++ b/channels_postgres/db.py
@@ -72,11 +72,12 @@ class DatabaseLayer:
             cur = await conn.cursor()
             await cur.execute(delete_sql)
 
-    async def delete_expired_messages(self, db_params):
-        expire = 60 * random.randint(10, 20)
+    async def delete_expired_messages(self, db_params, expire):
+        if expire is None:
+            expire = 60 * random.randint(10, 20)
         self.logger.debug('Deleting expired messages in %s seconds...', expire)
 
-        await asyncio.sleep(60)
+        await asyncio.sleep(expire)
         delete_sql = (
             'DELETE FROM channels_postgres_message '
             'WHERE expire < NOW()'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ crypto_requires = ['cryptography>=1.3.0']
 test_requires = crypto_requires + [
     'pytest',
     'pytest-asyncio',
-    'async_generator',
     'async-timeout',
 ]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,6 @@ from django.conf import settings
 import pytest
 import async_timeout
 from asgiref.sync import async_to_sync
-from async_generator import async_generator, yield_
 
 django.setup()  # noqa
 from channels_postgres.core import PostgresChannelLayer  # noqa
@@ -52,11 +51,10 @@ async def group_send_three_messages_with_delay(group_name, channel_layer, delay)
 
 
 @pytest.fixture()
-@async_generator
 async def channel_layer():
     """Channel layer fixture that flushes automatically."""
     channel_layer = PostgresChannelLayer(**settings.DATABASES['channels_postgres'])
-    await yield_(channel_layer)
+    yield channel_layer
     await channel_layer.flush()
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -162,7 +162,7 @@ async def test_groups_basic(channel_layer):
     await channel_layer.group_add("test-group", channel_name1)
     await channel_layer.group_add("test-group", channel_name2)
     await channel_layer.group_add("test-group", channel_name3)
-    await channel_layer.group_discard("test-group", channel_name2)
+    await channel_layer.group_discard("test-group", channel_name2, expire=1)
     await channel_layer.group_send("test-group", {"type": "message.1"})
     # Make sure we get the message on the two channels that were in
     async with async_timeout.timeout(1):


### PR DESCRIPTION
It's no longwer necessary for python3.6+

Deprecate python3.6 (Python 3.6 tests are now allowed to fail in CI)