### PR TITLE
fix: Close db connections for user facing methods

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     services:
       postgres:
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox

--- a/channels_postgres/core.py
+++ b/channels_postgres/core.py
@@ -114,6 +114,7 @@ class PostgresChannelLayer(BaseChannelLayer):
             await self.django_db.send_to_channel(
                 conn, '', message, self.expiry, channel=channel
             )
+            conn.close()
 
     async def _get_message_from_channel(self, channel):
         retrieve_events_sql = f'LISTEN "{channel}";'
@@ -213,6 +214,7 @@ class PostgresChannelLayer(BaseChannelLayer):
             await self.django_db.add_channel_to_group(
                 conn, group_key, channel, self.group_expiry
             )
+            conn.close()
 
     async def group_discard(self, group, channel, expire=None):
         """
@@ -231,6 +233,8 @@ class PostgresChannelLayer(BaseChannelLayer):
         with await pool as conn:
             cur = await conn.cursor()
             await cur.execute(delete_channel_sql, (group_key, channel))
+
+            conn.close()
 
         # Delete expired groups (if enabled) and messages
         if self.group_expiry > 0:
@@ -251,6 +255,7 @@ class PostgresChannelLayer(BaseChannelLayer):
             await self.django_db.send_to_channel(
                 conn, group_key, message, self.expiry
             )
+            conn.close()
 
     def _group_key(self, group):
         """Common function to make the storage key for the group."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ universal=1
 
 [tool:pytest]
 addopts = -p no:django tests/
+asyncio_mode = auto
 
 [flake8]
 exclude = venv/*,tox/*,specs/*,build/*

--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,12 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'msgpack~=1.0',
-        'asgiref>=3.2.10,<4',
-        'channels<4',
-        'aiopg>=1.3.1'
+        'asgiref~=3.5.2',
+        'channels~=4.0.0',
+        'aiopg~=1.3.1'
     ],
     extras_require={'cryptography': crypto_requires, 'tests': test_requires},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}
+    py{37,38,39, 310}
     qa
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39, 310}
+    py{37, 38, 39, 310}
     qa
 
 [testenv]


### PR DESCRIPTION
Each DB pool is tied to an event loop. Django creates a new loop on each request;
Hence, trying to acquire a new connection from the existing DB pool fails because the async Task/Future is tied to a different loop.

From the Django docs:

> Under a WSGI server, async views will run in their own, one-off event loop. This means you can use async features, like concurrent async HTTP requests, without any issues, but you will not get the benefits of an async stack.


This change will impact the performance of users that use the user-facing (e.g `group_add`, `send`) functions in a non-WSGI environment since a new connection has to be established every time compared to reusing existing connections from the DB pool.

I'll still keep the connection pool around even though it provides no benefit for now (since the connections are closed and reopened every time).
I plan to introduce a Non-standard configuration to toggle this behaviour so non-WSGI users don't suffer from degraded performance