### PR TITLE
Fixed required asgiref version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.9',
     install_requires=[
         'msgpack~=1.0.7',
-        'asgiref~=3.7.2,<4',
+        'asgiref>=3.7.2,<4',
         'channels~=4.0.0',
         'aiopg~=1.4.0'
     ],


### PR DESCRIPTION
Now accepts any version `>= 3.7.2` and `< 4.0.0`.  Previously it was constrained to `3.7.x`.

Fixes issue #32 