### PR TITLE
chore: Add compatibility with channels 4.2.0, Django 5.1, Python 3.13

### DIFF
--- a/channels_postgres/core.py
+++ b/channels_postgres/core.py
@@ -41,7 +41,7 @@ class PostgresChannelLayer(BaseChannelLayer):
 
     def __init__(
         self,
-        prefix="asgi",
+        prefix='asgi',
         expiry=60,
         group_expiry=0,
         symmetric_encryption_keys=None,
@@ -57,9 +57,9 @@ class PostgresChannelLayer(BaseChannelLayer):
         self.async_lib_config = config
 
         try:
-            kwargs["OPTIONS"]
+            kwargs['OPTIONS']
         except KeyError:
-            kwargs["OPTIONS"] = {}
+            kwargs['OPTIONS'] = {}
 
         db_wrapper = DatabaseWrapper(kwargs)
         self.db_params = db_wrapper.get_connection_params()
@@ -84,13 +84,13 @@ class PostgresChannelLayer(BaseChannelLayer):
         if symmetric_encryption_keys:
             if isinstance(symmetric_encryption_keys, (str, bytes)):
                 raise ValueError(
-                    "symmetric_encryption_keys must be a list of possible keys"
+                    'symmetric_encryption_keys must be a list of possible keys'
                 )
             try:
                 from cryptography.fernet import MultiFernet
             except ImportError:
                 raise ValueError(
-                    "Cannot run with encryption without `cryptography` " "installed."
+                    'Cannot run with encryption without `cryptography` installed.'
                 )
             sub_fernets = [self.make_fernet(key) for key in symmetric_encryption_keys]
             self.crypter = MultiFernet(sub_fernets)
@@ -99,24 +99,24 @@ class PostgresChannelLayer(BaseChannelLayer):
 
     """ Channel layer API """
 
-    extensions = ["groups", "flush"]
+    extensions = ['groups', 'flush']
 
     async def send(self, channel, message):
         """Send a message onto a (general or specific) channel."""
         # Typecheck
-        assert isinstance(message, dict), "message is not a dict"
+        assert isinstance(message, dict), 'message is not a dict'
         try:
-            assert self.require_valid_channel_name(channel), "Channel name not valid"
+            assert self.require_valid_channel_name(channel), 'Channel name not valid'
         except AttributeError:
-            assert self.valid_channel_name(channel), "Channel name not valid"
+            assert self.valid_channel_name(channel), 'Channel name not valid'
         # Make sure the message does not contain reserved keys
-        assert "__asgi_channel__" not in message
+        assert '__asgi_channel__' not in message
         message = self.serialize(message)
 
         _, pool = await self.get_pool()
         with await pool as conn:
             await self.django_db.send_to_channel(
-                conn, "", message, self.expiry, channel=channel
+                conn, '', message, self.expiry, channel=channel
             )
             conn.close()
 
@@ -143,7 +143,7 @@ class PostgresChannelLayer(BaseChannelLayer):
 
             if not message:
                 # Unlisten and clear pending messages (From other connections) from the queue
-                await cur.execute("UNLISTEN *;")
+                await cur.execute('UNLISTEN *;')
                 for _ in range(conn.notifies.qsize()):
                     conn.notifies.get_nowait()
 
@@ -152,8 +152,8 @@ class PostgresChannelLayer(BaseChannelLayer):
                 message_id = event.payload
 
                 retrieve_message_sql = (
-                    "DELETE FROM channels_postgres_message "
-                    "WHERE id=%s RETURNING message;"
+                    'DELETE FROM channels_postgres_message '
+                    'WHERE id=%s RETURNING message;'
                 )
                 await cur.execute(retrieve_message_sql, (message_id,))
                 message = await cur.fetchone()
@@ -169,27 +169,23 @@ class PostgresChannelLayer(BaseChannelLayer):
         will be given the message when it arrives.
         """
         try:
-            assert self.require_valid_channel_name(channel), "Channel name not valid"
+            assert self.require_valid_channel_name(channel), 'Channel name not valid'
         except AttributeError:
-            assert self.valid_channel_name(channel), "Channel name not valid"
-        if "!" in channel:
+            assert self.valid_channel_name(channel), 'Channel name not valid'
+        if '!' in channel:
             real_channel = self.non_local_name(channel)
-            assert real_channel.endswith(
-                self.client_prefix + "!"
-            ), "Wrong client prefix"
+            assert real_channel.endswith(self.client_prefix + '!'), (
+                'Wrong client prefix'
+            )
 
         return await self._get_message_from_channel(channel)
 
-    async def new_channel(self, prefix="specific"):
+    async def new_channel(self, prefix='specific'):
         """
         Returns a new channel name that can be used by something in our
         process as a specific channel.
         """
-        return "%s.%s!%s" % (
-            prefix,
-            self.client_prefix,
-            uuid.uuid4().hex,
-        )
+        return '%s.%s!%s' % (prefix, self.client_prefix, uuid.uuid4().hex)
 
     """ Flush extension """
 
@@ -201,8 +197,8 @@ class PostgresChannelLayer(BaseChannelLayer):
         Postgres doesn't provide access to this table/queue.
         """
         truncate_table_sql = (
-            "TRUNCATE channels_postgres_groupchannel; "
-            "TRUNCATE channels_postgres_message;"
+            'TRUNCATE channels_postgres_groupchannel; '
+            'TRUNCATE channels_postgres_message;'
         )
 
         _, pool = await self.get_pool()
@@ -229,19 +225,19 @@ class PostgresChannelLayer(BaseChannelLayer):
         does nothing otherwise (does not error)
         """
         try:
-            assert self.require_valid_group_name(group), "Group name not valid"
+            assert self.require_valid_group_name(group), 'Group name not valid'
         except AttributeError:
-            assert self.valid_group_name(group), "Group name not valid"
+            assert self.valid_group_name(group), 'Group name not valid'
         try:
-            assert self.require_valid_channel_name(channel), "Channel name not valid"
+            assert self.require_valid_channel_name(channel), 'Channel name not valid'
         except AttributeError:
-            assert self.valid_channel_name(channel), "Channel name not valid"
+            assert self.valid_channel_name(channel), 'Channel name not valid'
 
         group_key = self._group_key(group)
 
         delete_channel_sql = (
-            "DELETE FROM channels_postgres_groupchannel "
-            "WHERE group_key=%s AND channel =%s"
+            'DELETE FROM channels_postgres_groupchannel '
+            'WHERE group_key=%s AND channel =%s'
         )
         _, pool = await self.get_pool()
         with await pool as conn:
@@ -259,9 +255,9 @@ class PostgresChannelLayer(BaseChannelLayer):
     async def group_send(self, group, message):
         """Sends a message to the entire group."""
         try:
-            assert self.require_valid_group_name(group), "Group name not valid"
+            assert self.require_valid_group_name(group), 'Group name not valid'
         except AttributeError:
-            assert self.valid_group_name(group), "Group name not valid"
+            assert self.valid_group_name(group), 'Group name not valid'
 
         group_key = self._group_key(group)
         # Retrieve list of all channel names related to the group
@@ -274,7 +270,7 @@ class PostgresChannelLayer(BaseChannelLayer):
 
     def _group_key(self, group):
         """Common function to make the storage key for the group."""
-        return "%s:group:%s" % (self.prefix, group)
+        return '%s:group:%s' % (self.prefix, group)
 
     """ Serialization """
 

--- a/setup.py
+++ b/setup.py
@@ -5,37 +5,33 @@ from setuptools import find_packages, setup
 from channels_postgres import __version__
 
 
-crypto_requires = ["cryptography>=1.3.0"]
+crypto_requires = ['cryptography>=1.3.0']
 
-test_requires = crypto_requires + [
-    "pytest",
-    "pytest-asyncio",
-    "async-timeout",
-]
+test_requires = crypto_requires + ['pytest', 'pytest-asyncio', 'async-timeout']
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name="channels_postgres",
+    name='channels_postgres',
     version=__version__,
-    url="http://github.com/danidee10/channels_postgres/",
-    author="Daniel Osaetin",
-    author_email="f805nqs6j@relay.firefox.com",
-    description="PostgreSQL-backed ASGI channel layer implementation",
+    url='http://github.com/danidee10/channels_postgres/',
+    author='Daniel Osaetin',
+    author_email='f805nqs6j@relay.firefox.com',
+    description='PostgreSQL-backed ASGI channel layer implementation',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    license="BSD",
+    long_description_content_type='text/markdown',
+    license='BSD',
     zip_safe=False,
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires='>=3.9',
     install_requires=[
-        "msgpack~=1.0.7",
-        "asgiref>=3.7.2,<4",
-        "channels>=4.0.0",
-        "aiopg~=1.4.0",
+        'msgpack~=1.0.7',
+        'asgiref>=3.7.2,<4',
+        'channels>=4.0.0',
+        'aiopg~=1.4.0',
     ],
-    extras_require={"cryptography": crypto_requires, "tests": test_requires},
+    extras_require={'cryptography': crypto_requires, 'tests': test_requires},
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'msgpack~=1.0.7',
         'asgiref>=3.7.2,<4',
-        'channels>=4.0.0',
+        'channels>=4.0.0,<5',
         'aiopg~=1.4.0',
     ],
     extras_require={'cryptography': crypto_requires, 'tests': test_requires},

--- a/setup.py
+++ b/setup.py
@@ -5,37 +5,37 @@ from setuptools import find_packages, setup
 from channels_postgres import __version__
 
 
-crypto_requires = ['cryptography>=1.3.0']
+crypto_requires = ["cryptography>=1.3.0"]
 
 test_requires = crypto_requires + [
-    'pytest',
-    'pytest-asyncio',
-    'async-timeout',
+    "pytest",
+    "pytest-asyncio",
+    "async-timeout",
 ]
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='channels_postgres',
+    name="channels_postgres",
     version=__version__,
-    url='http://github.com/danidee10/channels_postgres/',
-    author='Daniel Osaetin',
-    author_email='f805nqs6j@relay.firefox.com',
-    description='PostgreSQL-backed ASGI channel layer implementation',
+    url="http://github.com/danidee10/channels_postgres/",
+    author="Daniel Osaetin",
+    author_email="f805nqs6j@relay.firefox.com",
+    description="PostgreSQL-backed ASGI channel layer implementation",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    license='BSD',
+    long_description_content_type="text/markdown",
+    license="BSD",
     zip_safe=False,
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires='>=3.9',
+    python_requires=">=3.9",
     install_requires=[
-        'msgpack~=1.0.7',
-        'asgiref>=3.7.2,<4',
-        'channels~=4.0.0',
-        'aiopg~=1.4.0'
+        "msgpack~=1.0.7",
+        "asgiref>=3.7.2,<4",
+        "channels>=4.0.0",
+        "aiopg~=1.4.0",
     ],
-    extras_require={'cryptography': crypto_requires, 'tests': test_requires},
+    extras_require={"cryptography": crypto_requires, "tests": test_requires},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
     py39-django{32,40,41,42},
-    py310-django{32,40,41,42,50,main},
-    py311-django{32,40,41,42,50,main},
-    py312-django{32,40,41,42,50,main},
+    py310-django{32,40,41,42,50,51},
+    py311-django{41,42,50,51},
+    py312-django{42,50,51,main},
+    py313-django{51,main},
     qa
 
 [testenv]
@@ -15,6 +16,7 @@ deps =
     django41: Django >=4.1, <4.2
     django42: Django >=4.2, <5.0
     django50: Django >=5.0, <5.1
+    django51: Django >=5.1, <5.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
 commands =
     python -m django migrate --database channels_postgres


### PR DESCRIPTION
Add try/except with calls to (require_)valid_channel_name and (require_)valid_group_name for compatibility with channels 4.2.0.

Fixup the tox.ini test matrix to match current Django/Python support matrix.

tox run is successful!