### PR TITLE
fix: Fix typo in PSYCOPG_OPTIONS

### DIFF
--- a/channels_postgres/core.py
+++ b/channels_postgres/core.py
@@ -82,7 +82,7 @@ class PostgresChannelLayer(BaseChannelLayer):  # type: ignore  # pylint: disable
         db_params.pop('context')
         self.db_params = db_params
 
-        psycopg_options = kwargs.get('PYSCOPG_OPTIONS', {})
+        psycopg_options = kwargs.get('PSYCOPG_OPTIONS', {})
         self.django_db = DatabaseLayer(psycopg_options, self.db_params, logger=logger)
 
     def _setup_encryption(

--- a/channels_postgres/db.py
+++ b/channels_postgres/db.py
@@ -311,7 +311,11 @@ class DatabaseLayer:
 
     async def delete_channel_group(self, group_key: str, channel: str) -> None:
         """Deletes a channel from a group"""
-        await GroupChannel.objects.filter(group_key=group_key, channel=channel).adelete()
+        await (
+            GroupChannel.objects.using(self.using)
+            .filter(group_key=group_key, channel=channel)
+            .adelete()
+        )
 
     async def flush(self) -> None:
         """


### PR DESCRIPTION
### Other changes

- Use `self.using` parameter to execute django queries against the configured `"channels_postgres"` database

Closes #60 